### PR TITLE
Renaming save -> insert

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ We try to follow the naming conventions as described in this interface for all m
 ```go
 type Model interface {
     Load(id int64) error    // Loads the contents of model entry with ID into current struct
-    Save() error            // Saves the state of the current struct into the DB
+    Insert() error          // Inserts the state of the current struct into the DB
     Update() error          // Updates the state of the current struct to the DB
     Delete() error          // Removes the current struct from the DB
 }

--- a/controllers/topics_controller.go
+++ b/controllers/topics_controller.go
@@ -102,7 +102,7 @@ func (tc *TopicsController) Create(c *echo.Context) error {
 	// Creating the topic
 	topic := new(models.Topic)
 	topic.Name = name
-	err := topic.Save()
+	err := topic.Insert()
 	if err != nil {
 		resp.SetResponse(http.StatusConflict, nil)
 		return nil

--- a/models/topic.go
+++ b/models/topic.go
@@ -51,7 +51,7 @@ func (t *Topic) Load(id int64) error {
 	return t.consumeRow(row)
 }
 
-func (t *Topic) Save() error {
+func (t *Topic) Insert() error {
 	// Putting into database
 	database := db.Get()
 	row := database.QueryRow("INSERT INTO topics VALUES(default, $1, default, default) RETURNING *",


### PR DESCRIPTION
@roideuniverse mentioned `Save` was a little ambiguous of what it actually does, to which I agreed to his point.

Renaming it to insert, as we've already got `Update` + `Delete` matching their relative SQL commands.