### PR TITLE
Adding custom 404 handling

### DIFF
--- a/request/request.go
+++ b/request/request.go
@@ -3,6 +3,7 @@ package request
 import (
 	"github.com/carrot/burrow/controllers"
 	"github.com/carrot/burrow/middleware"
+	"github.com/carrot/burrow/response"
 	"github.com/labstack/echo"
 	echo_middleware "github.com/labstack/echo/middleware"
 )
@@ -20,6 +21,19 @@ func BuildEcho() *echo.Echo {
 
 	e.Use(echo_middleware.Logger())
 	e.Use(middleware.Recover())
+
+	// -------------------
+	// HTTP Error Handler
+	// -------------------
+
+	e.SetHTTPErrorHandler(func(err error, context *echo.Context) {
+		httpError, ok := err.(*echo.HTTPError)
+		if ok {
+			response := response.New(context)
+			response.SetResponse(httpError.Code(), nil)
+			response.Render()
+		}
+	})
 
 	// ------------
 	// Controllers


### PR DESCRIPTION
Now if you hit an endpoint, it will respond with a 404, but also with
the standard response body for a 404, as opposed to Echo's default